### PR TITLE
Programmatic Accuracy Validation + Fix Validator Check Limit Function + Improve logging for miner and validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ main/*
 *.1
 *.onnx
 example_env.env
+bittensor/

--- a/logicnet/base/miner.py
+++ b/logicnet/base/miner.py
@@ -19,7 +19,6 @@ import time
 import asyncio
 import threading
 import traceback
-from termcolor import colored
 
 import bittensor as bt
 
@@ -38,7 +37,7 @@ class BaseMinerNeuron(BaseNeuron):
         self.axon = bt.axon(wallet=self.wallet, config=self.config)
 
         # Attach determiners which functions are called when servicing a request.
-        bt.logging.info(colored("🔗 Attaching forward function to miner axon.", "green"))
+        bt.logging.info("Attaching forward function to miner axon.")
         self.axon.attach(
             forward_fn=self.forward,
             blacklist_fn=self.blacklist,
@@ -46,7 +45,7 @@ class BaseMinerNeuron(BaseNeuron):
             forward_fn=self.forward_info,
             blacklist_fn=self.blacklist_info,
         )
-        bt.logging.info(colored(f"🧠 Axon created: {self.axon}", "green"))
+        bt.logging.info(f"Axon created: {self.axon}")
 
         # Instantiate runners
         self.should_exit: bool = False
@@ -83,14 +82,14 @@ class BaseMinerNeuron(BaseNeuron):
         # Serve passes the axon information to the network + netuid we are hosting on.
         # This will auto-update if the axon port of external ip have changed.
         bt.logging.info(
-            colored(f"🌐 Serving miner axon {self.axon} on network: {self.config.subtensor.chain_endpoint} with netuid: {self.config.netuid}", "blue")
+            f"Serving miner axon {self.axon} on network: {self.config.subtensor.chain_endpoint} with netuid: {self.config.netuid}"
         )
         self.axon.serve(netuid=self.config.netuid, subtensor=self.subtensor)
 
         # Start  starts the miner's axon, making it active on the network.
         self.axon.start()
 
-        bt.logging.info(colored(f"🚀 Miner starting at block: {self.block}", "blue"))
+        bt.logging.info(f"Miner starting at block: {self.block}")
 
         # This loop maintains the miner's operations until intentionally stopped.
         try:
@@ -113,12 +112,12 @@ class BaseMinerNeuron(BaseNeuron):
         # If someone intentionally stops the miner, it'll safely terminate operations.
         except KeyboardInterrupt:
             self.axon.stop()
-            bt.logging.success(colored("🛑 Miner killed by keyboard interrupt.", "red"))
+            bt.logging.success("Miner killed by keyboard interrupt.")
             exit()
 
         # In case of unforeseen errors, the miner will log the error and continue operations.
         except Exception:
-            bt.logging.error(colored(traceback.format_exc(), "red"))
+            bt.logging.error(traceback.format_exc())
 
     def run_in_background_thread(self):
         """
@@ -126,23 +125,23 @@ class BaseMinerNeuron(BaseNeuron):
         This is useful for non-blocking operations.
         """
         if not self.is_running:
-            bt.logging.debug(colored("🔄 Starting miner in background thread.", "yellow"))
+            bt.logging.debug("Starting miner in background thread.")
             self.should_exit = False
             self.thread = threading.Thread(target=self.run, daemon=True)
             self.thread.start()
             self.is_running = True
-            bt.logging.debug(colored("✅ Started", "yellow"))
+            bt.logging.debug("Started")
 
     def stop_run_thread(self):
         """
         Stops the miner's operations that are running in the background thread.
         """
         if self.is_running:
-            bt.logging.debug(colored("🛑 Stopping miner in background thread.", "yellow"))
+            bt.logging.debug("Stopping miner in background thread.")
             self.should_exit = True
             self.thread.join(5)
             self.is_running = False
-            bt.logging.debug(colored("✅ Stopped", "yellow"))
+            bt.logging.debug("Stopped")
 
     def __enter__(self):
         """

--- a/logicnet/base/miner.py
+++ b/logicnet/base/miner.py
@@ -1,20 +1,3 @@
-# The MIT License (MIT)
-# Copyright © 2023 Yuma Rao
-
-# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
-# documentation files (the “Software”), to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
-# the Software.
-
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
-# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
-
 import time
 import asyncio
 import threading
@@ -37,7 +20,7 @@ class BaseMinerNeuron(BaseNeuron):
         self.axon = bt.axon(wallet=self.wallet, config=self.config)
 
         # Attach determiners which functions are called when servicing a request.
-        bt.logging.info("Attaching forward function to miner axon.")
+        bt.logging.info("\033[1;32m🧠 Attaching forward function to miner axon.\033[0m")
         self.axon.attach(
             forward_fn=self.forward,
             blacklist_fn=self.blacklist,
@@ -45,7 +28,7 @@ class BaseMinerNeuron(BaseNeuron):
             forward_fn=self.forward_info,
             blacklist_fn=self.blacklist_info,
         )
-        bt.logging.info(f"Axon created: {self.axon}")
+        bt.logging.info(f"\033[1;32m🧠 Axon created: {self.axon}\033[0m")
 
         # Instantiate runners
         self.should_exit: bool = False
@@ -82,14 +65,14 @@ class BaseMinerNeuron(BaseNeuron):
         # Serve passes the axon information to the network + netuid we are hosting on.
         # This will auto-update if the axon port of external ip have changed.
         bt.logging.info(
-            f"Serving miner axon {self.axon} on network: {self.config.subtensor.chain_endpoint} with netuid: {self.config.netuid}"
+            f"\033[1;32m🧠 Serving miner axon {self.axon} on network: {self.config.subtensor.chain_endpoint} with netuid: {self.config.netuid}\033[0m"
         )
         self.axon.serve(netuid=self.config.netuid, subtensor=self.subtensor)
 
         # Start  starts the miner's axon, making it active on the network.
         self.axon.start()
 
-        bt.logging.info(f"Miner starting at block: {self.block}")
+        bt.logging.info(f"\033[1;32m🧠 Miner starting at block: {self.block}\033[0m")
 
         # This loop maintains the miner's operations until intentionally stopped.
         try:
@@ -112,12 +95,12 @@ class BaseMinerNeuron(BaseNeuron):
         # If someone intentionally stops the miner, it'll safely terminate operations.
         except KeyboardInterrupt:
             self.axon.stop()
-            bt.logging.success("Miner killed by keyboard interrupt.")
+            bt.logging.success("\033[1;31m🛑 Miner killed by keyboard interrupt.\033[0m")
             exit()
 
         # In case of unforeseen errors, the miner will log the error and continue operations.
         except Exception:
-            bt.logging.error(traceback.format_exc())
+            bt.logging.error(f"\033[1;31m❌ {traceback.format_exc()}\033[0m")
 
     def run_in_background_thread(self):
         """
@@ -125,23 +108,23 @@ class BaseMinerNeuron(BaseNeuron):
         This is useful for non-blocking operations.
         """
         if not self.is_running:
-            bt.logging.debug("Starting miner in background thread.")
+            bt.logging.debug("\033[1;34m🔄 Starting miner in background thread.\033[0m")
             self.should_exit = False
             self.thread = threading.Thread(target=self.run, daemon=True)
             self.thread.start()
             self.is_running = True
-            bt.logging.debug("Started")
+            bt.logging.debug("\033[1;34m🔄 Started\033[0m")
 
     def stop_run_thread(self):
         """
         Stops the miner's operations that are running in the background thread.
         """
         if self.is_running:
-            bt.logging.debug("Stopping miner in background thread.")
+            bt.logging.debug("\033[1;34m🔄 Stopping miner in background thread.\033[0m")
             self.should_exit = True
             self.thread.join(5)
             self.is_running = False
-            bt.logging.debug("Stopped")
+            bt.logging.debug("\033[1;34m🔄 Stopped\033[0m")
 
     def __enter__(self):
         """

--- a/logicnet/base/miner.py
+++ b/logicnet/base/miner.py
@@ -19,6 +19,7 @@ import time
 import asyncio
 import threading
 import traceback
+from termcolor import colored
 
 import bittensor as bt
 
@@ -37,7 +38,7 @@ class BaseMinerNeuron(BaseNeuron):
         self.axon = bt.axon(wallet=self.wallet, config=self.config)
 
         # Attach determiners which functions are called when servicing a request.
-        bt.logging.info("Attaching forward function to miner axon.")
+        bt.logging.info(colored("🔗 Attaching forward function to miner axon.", "green"))
         self.axon.attach(
             forward_fn=self.forward,
             blacklist_fn=self.blacklist,
@@ -45,7 +46,7 @@ class BaseMinerNeuron(BaseNeuron):
             forward_fn=self.forward_info,
             blacklist_fn=self.blacklist_info,
         )
-        bt.logging.info(f"Axon created: {self.axon}")
+        bt.logging.info(colored(f"🧠 Axon created: {self.axon}", "green"))
 
         # Instantiate runners
         self.should_exit: bool = False
@@ -82,14 +83,14 @@ class BaseMinerNeuron(BaseNeuron):
         # Serve passes the axon information to the network + netuid we are hosting on.
         # This will auto-update if the axon port of external ip have changed.
         bt.logging.info(
-            f"Serving miner axon {self.axon} on network: {self.config.subtensor.chain_endpoint} with netuid: {self.config.netuid}"
+            colored(f"🌐 Serving miner axon {self.axon} on network: {self.config.subtensor.chain_endpoint} with netuid: {self.config.netuid}", "blue")
         )
         self.axon.serve(netuid=self.config.netuid, subtensor=self.subtensor)
 
         # Start  starts the miner's axon, making it active on the network.
         self.axon.start()
 
-        bt.logging.info(f"Miner starting at block: {self.block}")
+        bt.logging.info(colored(f"🚀 Miner starting at block: {self.block}", "blue"))
 
         # This loop maintains the miner's operations until intentionally stopped.
         try:
@@ -112,12 +113,12 @@ class BaseMinerNeuron(BaseNeuron):
         # If someone intentionally stops the miner, it'll safely terminate operations.
         except KeyboardInterrupt:
             self.axon.stop()
-            bt.logging.success("Miner killed by keyboard interrupt.")
+            bt.logging.success(colored("🛑 Miner killed by keyboard interrupt.", "red"))
             exit()
 
         # In case of unforeseen errors, the miner will log the error and continue operations.
         except Exception:
-            bt.logging.error(traceback.format_exc())
+            bt.logging.error(colored(traceback.format_exc(), "red"))
 
     def run_in_background_thread(self):
         """
@@ -125,23 +126,23 @@ class BaseMinerNeuron(BaseNeuron):
         This is useful for non-blocking operations.
         """
         if not self.is_running:
-            bt.logging.debug("Starting miner in background thread.")
+            bt.logging.debug(colored("🔄 Starting miner in background thread.", "yellow"))
             self.should_exit = False
             self.thread = threading.Thread(target=self.run, daemon=True)
             self.thread.start()
             self.is_running = True
-            bt.logging.debug("Started")
+            bt.logging.debug(colored("✅ Started", "yellow"))
 
     def stop_run_thread(self):
         """
         Stops the miner's operations that are running in the background thread.
         """
         if self.is_running:
-            bt.logging.debug("Stopping miner in background thread.")
+            bt.logging.debug(colored("🛑 Stopping miner in background thread.", "yellow"))
             self.should_exit = True
             self.thread.join(5)
             self.is_running = False
-            bt.logging.debug("Stopped")
+            bt.logging.debug(colored("✅ Stopped", "yellow"))
 
     def __enter__(self):
         """

--- a/logicnet/base/validator.py
+++ b/logicnet/base/validator.py
@@ -1,23 +1,3 @@
-# The MIT License (MIT)
-# Copyright © 2023 Yuma Rao
-# TODO(developer): Set your name
-# Copyright © 2023 <your name>
-
-# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
-# documentation files (the “Software”), to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
-# the Software.
-
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
-# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
-
-
 import copy
 import torch
 import asyncio
@@ -43,10 +23,10 @@ class BaseValidatorNeuron(BaseNeuron):
 
         # Dendrite lets us send messages to other nodes (axons) in the network.
         self.dendrite = bt.dendrite(wallet=self.wallet)
-        bt.logging.info(f"Dendrite: {self.dendrite}")
+        bt.logging.info(f"\033[1;32m🔗 Dendrite: {self.dendrite}\033[0m")
 
         # Set up initial scoring weights for validation
-        bt.logging.info("Building validation weights.")
+        bt.logging.info("\033[1;32m⚖️ Building validation weights.\033[0m")
         self.scores = torch.zeros_like(self.metagraph.S, dtype=torch.float32)
 
         # Init sync with the network. Updates the metagraph.
@@ -56,7 +36,7 @@ class BaseValidatorNeuron(BaseNeuron):
         if not self.config.neuron.axon_off:
             self.serve_axon()
         else:
-            bt.logging.warning("axon off, not serving ip to chain.")
+            bt.logging.warning("\033[1;33m⚠️ axon off, not serving ip to chain.\033[0m")
 
         # Create asyncio event loop to manage async tasks.
         self.loop = asyncio.get_event_loop()
@@ -70,7 +50,7 @@ class BaseValidatorNeuron(BaseNeuron):
     def serve_axon(self):
         """Serve axon to enable external connections."""
 
-        bt.logging.info("serving ip to chain...")
+        bt.logging.info("\033[1;32m🌐 serving ip to chain...\033[0m")
         try:
             self.axon = bt.axon(wallet=self.wallet, config=self.config)
 
@@ -80,11 +60,11 @@ class BaseValidatorNeuron(BaseNeuron):
                     axon=self.axon,
                 )
             except Exception as e:
-                bt.logging.error(f"Failed to serve Axon with exception: {e}")
+                bt.logging.error(f"\033[1;31m❌ Failed to serve Axon with exception: {e}\033[0m")
                 pass
 
         except Exception as e:
-            bt.logging.error(f"Failed to create Axon initialize with exception: {e}")
+            bt.logging.error(f"\033[1;31m❌ Failed to create Axon initialize with exception: {e}\033[0m")
             pass
 
     def run(self):
@@ -111,12 +91,12 @@ class BaseValidatorNeuron(BaseNeuron):
         self.sync()
 
         bt.logging.info(
-            f"Running validator on network: {self.config.subtensor.chain_endpoint} with netuid: {self.config.netuid}"
+            f"\033[1;32m🧠 Running validator on network: {self.config.subtensor.chain_endpoint} with netuid: {self.config.netuid}\033[0m"
         )
         if hasattr(self, "axon"):
             f"Axon: {self.axon}"
 
-        bt.logging.info(f"Validator starting at block: {self.block}")
+        bt.logging.info(f"\033[1;32m🧱 Validator starting at block: {self.block}\033[0m")
 
         # This loop maintains the validator's operations until intentionally stopped.
         while True:
@@ -125,12 +105,12 @@ class BaseValidatorNeuron(BaseNeuron):
                     try:
                         self.validator_proxy.get_credentials()
                         bt.logging.info(
-                            "Validator proxy ping to proxy-client successfully"
+                            "\033[1;32m🔌 Validator proxy ping to proxy-client successfully\033[0m"
                         )
                     except Exception:
-                        bt.logging.warning("Warning, proxy can't ping to proxy-client.")
+                        bt.logging.warning("\033[1;33m⚠️ Warning, proxy can't ping to proxy-client.\033[0m")
 
-                bt.logging.info(f"step({self.step}) block({self.block})")
+                bt.logging.info(f"\033[1;32m🔄 step({self.step}) block({self.block})\033[0m")
 
                 # Run forward.
                 try:
@@ -151,12 +131,12 @@ class BaseValidatorNeuron(BaseNeuron):
             # If someone intentionally stops the validator, it'll safely terminate operations.
             except KeyboardInterrupt:
                 self.axon.stop()
-                bt.logging.success("Validator killed by keyboard interrupt.")
+                bt.logging.success("\033[1;32m🛑 Validator killed by keyboard interrupt.\033[0m")
                 exit()
 
             # In case of unforeseen errors, the validator will log the error and continue operations.
             except Exception as err:
-                bt.logging.error("Error during validation", str(err))
+                bt.logging.error("\033[1;31m❌ Error during validation\033[0m", str(err))
                 bt.logging.debug(print_exception(type(err), err, err.__traceback__))
 
     def run_in_background_thread(self):
@@ -165,23 +145,23 @@ class BaseValidatorNeuron(BaseNeuron):
         This method facilitates the use of the validator in a 'with' statement.
         """
         if not self.is_running:
-            bt.logging.debug("Starting validator in background thread.")
+            bt.logging.debug("\033[1;32m🚀 Starting validator in background thread.\033[0m")
             self.should_exit = False
             self.thread = threading.Thread(target=self.run, daemon=True)
             self.thread.start()
             self.is_running = True
-            bt.logging.debug("Started")
+            bt.logging.debug("\033[1;32m✅ Started\033[0m")
 
     def stop_run_thread(self):
         """
         Stops the validator's operations that are running in the background thread.
         """
         if self.is_running:
-            bt.logging.debug("Stopping validator in background thread.")
+            bt.logging.debug("\033[1;33m🛑 Stopping validator in background thread.\033[0m")
             self.should_exit = True
             self.thread.join(5)
             self.is_running = False
-            bt.logging.debug("Stopped")
+            bt.logging.debug("\033[1;32m✅ Stopped\033[0m")
 
     def __enter__(self):
         self.run_in_background_thread()
@@ -201,11 +181,11 @@ class BaseValidatorNeuron(BaseNeuron):
                        None if the context was exited without an exception.
         """
         if self.is_running:
-            bt.logging.debug("Stopping validator in background thread.")
+            bt.logging.debug("\033[1;33m🛑 Stopping validator in background thread.\033[0m")
             self.should_exit = True
             self.thread.join(5)
             self.is_running = False
-            bt.logging.debug("Stopped")
+            bt.logging.debug("\033[1;32m✅ Stopped\033[0m")
 
     def set_weights(self):
         """
@@ -215,7 +195,7 @@ class BaseValidatorNeuron(BaseNeuron):
         # Check if self.scores contains any NaN values and log a warning if it does.
         if torch.isnan(self.scores).any():
             bt.logging.warning(
-                "Scores contain NaN values. This may be due to a lack of responses from miners, or a bug in your reward functions."
+                "\033[1;33m⚠️ Scores contain NaN values. This may be due to a lack of responses from miners, or a bug in your reward functions.\033[0m"
             )
 
         # Calculate the average reward for each uid across non-zero values.
@@ -249,11 +229,11 @@ class BaseValidatorNeuron(BaseNeuron):
             version_key=self.spec_version,
         )
 
-        bt.logging.info(f"Set weights: {processed_weights}")
+        bt.logging.info(f"\033[1;32m⚖️ Set weights: {processed_weights}\033[0m")
 
     def resync_metagraph(self):
         """Resyncs the metagraph and updates the hotkeys and moving averages based on the new metagraph."""
-        bt.logging.info("resync_metagraph()")
+        bt.logging.info("\033[1;32m🔄 resync_metagraph()\033[0m")
 
         # Copies state of metagraph before syncing.
         previous_metagraph = copy.deepcopy(self.metagraph)
@@ -266,11 +246,11 @@ class BaseValidatorNeuron(BaseNeuron):
             return
 
         bt.logging.info(
-            "Metagraph updated, re-syncing hotkeys, dendrite pool and moving averages"
+            "\033[1;32m🔄 Metagraph updated, re-syncing hotkeys, dendrite pool and moving averages\033[0m"
         )
         # Zero out all hotkeys that have been replaced.
         for uid, hotkey in enumerate(self.hotkeys):
-            if hotkey != self.metagraph.hotkeys[uid]:
+            if (hotkey != self.metagraph.hotkeys[uid]):
                 self.scores[uid] = 0  # hotkey has been replaced
 
         # Check to see if the metagraph has changed size.
@@ -290,7 +270,7 @@ class BaseValidatorNeuron(BaseNeuron):
 
         # Check if rewards contains NaN values.
         if torch.isnan(rewards).any():
-            bt.logging.warning(f"NaN values detected in rewards: {rewards}")
+            bt.logging.warning(f"\033[1;33m⚠️ NaN values detected in rewards: {rewards}\033[0m")
             # Replace any NaN values in rewards with 0.
             rewards = torch.nan_to_num(rewards, 0)
 
@@ -299,7 +279,7 @@ class BaseValidatorNeuron(BaseNeuron):
         scattered_rewards: torch.FloatTensor = self.scores.scatter(
             0, torch.tensor(uids).to(self.device), rewards
         ).to(self.device)
-        bt.logging.debug(f"Scattered rewards: {rewards}")
+        bt.logging.debug(f"\033[1;32m🔄 Scattered rewards: {rewards}\033[0m")
 
         # Update scores with rewards produced by this step.
         # shape: [ metagraph.n ]
@@ -307,4 +287,4 @@ class BaseValidatorNeuron(BaseNeuron):
         self.scores: torch.FloatTensor = alpha * scattered_rewards + (
             1 - alpha
         ) * self.scores.to(self.device)
-        bt.logging.info(f"Updated moving avg scores: {self.scores}")
+        bt.logging.info(f"\033[1;32m📈 Updated moving avg scores: {self.scores}\033[0m")

--- a/logicnet/miner/blacklist.py
+++ b/logicnet/miner/blacklist.py
@@ -11,24 +11,29 @@ def check_limit(
 ):
     bt.logging.info(self.validator_logs)
 
+    # Get the current max_request for the validator
+    max_request = volume_per_validator.get(uid, 1)
+
     if uid not in self.validator_logs:
         self.validator_logs[uid] = {
             "start_interval": time.time(),
-            "max_request": volume_per_validator.get(uid, 1),
+            "max_request": max_request,
             "request_counter": 1,
         }
-    elif time.time() - self.validator_logs[uid]["start_interval"] > interval:
-        self.validator_logs[uid] = {
-            "start_interval": time.time(),
-            "max_request": volume_per_validator[uid],
-            "request_counter": 1,
-        }
-        bt.logging.info(f"Reseting counting log for uid: {uid}")
     else:
-        self.validator_logs[uid]["request_counter"] += 1
-        if (
-            self.validator_logs[uid]["request_counter"]
-            > self.validator_logs[uid]["max_request"]
-        ):
-            return True
-    return False
+        # Update max_request in case it has changed
+        self.validator_logs[uid]["max_request"] = max_request
+
+        if time.time() - self.validator_logs[uid]["start_interval"] > interval:
+            self.validator_logs[uid]["start_interval"] = time.time()
+            self.validator_logs[uid]["request_counter"] = 1
+            bt.logging.info(f"Resetting counting log for uid: {uid}")
+        else:
+            self.validator_logs[uid]["request_counter"] += 1
+
+    # Log the current state for debugging
+    bt.logging.info(f"{self.validator_logs}")
+
+    if self.validator_logs[uid]["request_counter"] > self.validator_logs[uid]["max_request"]:
+        return True  # Limit exceeded
+    return False  # Within limit

--- a/logicnet/protocol.py
+++ b/logicnet/protocol.py
@@ -1,54 +1,54 @@
 import bittensor as bt
-import pydantic
-from typing import Optional, Union, List, Dict
+from pydantic import BaseModel, Field
+from typing import Optional, Union
 from bittensor.synapse import TerminalInfo
 
 class Information(bt.Synapse):
     """Information synapse for miner to send information to the validator. It won't be blacklisted by miner"""
-
     request_dict: dict = {}
     response_dict: dict = {}
-
 
 class LogicSynapse(bt.Synapse):
     """
     Logic Synapse for the LogicNet protocol
     """
-
     # MINER NEED TO FILL THIS INFORMATION
-    logic_question: str = pydantic.Field(
+    logic_question: str = Field(
         "",
         description="Logic question to be answered by miner. It can be noised question from the raw logic question from synthetic loop.",
     )
-    logic_answer: Union[str, object] = pydantic.Field(
+    logic_answer: Union[str, object] = Field(
         "", description="Short logic answer as a summary of the logic reasoning."
     )
-    logic_reasoning: str = pydantic.Field(
+    logic_reasoning: str = Field(
         "",
         description="Reasoning when answering the logic question",
     )
 
     # ONLY VISIBLE TO VALIDATOR
-    raw_logic_question: str = pydantic.Field(
+    raw_logic_question: str = Field(
         "",
         description="If this synapse from synthetic loop, this field will contain the raw logic question from the dataset.",
     )
-    ground_truth_answer: Union[str, object] = pydantic.Field(
+    ground_truth_answer: Union[str, object] = Field(
         "",
         description="Ground truth answer for the logic question. Very short, only the answer.",
     )
 
     # SYNAPSE INFORMATION
-    category: str = pydantic.Field(
+    category: str = Field(
         "",
         description="One of the categories in the Validator main.",
     )
-    timeout: int = pydantic.Field(
+    timeout: int = Field(
         64,
         description="Timeout for the miner to answer the logic question.",
     )
-    
-    terminal_info: Optional[TerminalInfo] = None
+
+    terminal_info: Optional[TerminalInfo] = Field(
+        default=None,
+        description="Contains detailed information about the terminal involved in the communication process."
+    )
 
     def miner_synapse(self):
         """
@@ -63,32 +63,3 @@ class LogicSynapse(bt.Synapse):
             "logic_answer": self.logic_answer,
             "logic_reasoning": self.logic_reasoning,
         }
-
-
-class LogicRequest(pydantic.BaseModel):
-    """
-    Logic Synapse for the LogicNet protocol
-    """
-
-    # MINER NEED TO FILL THIS INFORMATION
-    logic_question: str = pydantic.Field(
-        "",
-        description="Logic question to be answered by miner. It can be noised question from the raw logic question from synthetic loop.",
-    )
-    logic_answer: Union[str, object] = pydantic.Field(
-        "", description="Short logic answer as a summary of the logic reasoning."
-    )
-    logic_reasoning: str = pydantic.Field(
-        "",
-        description="Reasoning when answering the logic question",
-    )
-
-    # SYNAPSE INFORMATION
-    category: str = pydantic.Field(
-        "",
-        description="One of the categories in the Validator main.",
-    )
-    timeout: int = pydantic.Field(
-        64,
-        description="Timeout for the miner to answer the logic question.",
-    )

--- a/logicnet/protocol.py
+++ b/logicnet/protocol.py
@@ -1,7 +1,7 @@
 import bittensor as bt
 import pydantic
-from typing import Union
-
+from typing import Optional, Union, List, Dict
+from bittensor.synapse import TerminalInfo
 
 class Information(bt.Synapse):
     """Information synapse for miner to send information to the validator. It won't be blacklisted by miner"""
@@ -47,6 +47,8 @@ class LogicSynapse(bt.Synapse):
         64,
         description="Timeout for the miner to answer the logic question.",
     )
+    
+    terminal_info: Optional[TerminalInfo] = None
 
     def miner_synapse(self):
         """

--- a/logicnet/protocol.py
+++ b/logicnet/protocol.py
@@ -1,53 +1,51 @@
 import bittensor as bt
-from pydantic import BaseModel, Field
-from typing import Optional, Union
-from bittensor.synapse import TerminalInfo
+import pydantic
+from typing import Union
+
 
 class Information(bt.Synapse):
     """Information synapse for miner to send information to the validator. It won't be blacklisted by miner"""
+
     request_dict: dict = {}
     response_dict: dict = {}
+
 
 class LogicSynapse(bt.Synapse):
     """
     Logic Synapse for the LogicNet protocol
     """
+
     # MINER NEED TO FILL THIS INFORMATION
-    logic_question: str = Field(
+    logic_question: str = pydantic.Field(
         "",
         description="Logic question to be answered by miner. It can be noised question from the raw logic question from synthetic loop.",
     )
-    logic_answer: Union[str, object] = Field(
+    logic_answer: Union[str, object] = pydantic.Field(
         "", description="Short logic answer as a summary of the logic reasoning."
     )
-    logic_reasoning: str = Field(
+    logic_reasoning: str = pydantic.Field(
         "",
         description="Reasoning when answering the logic question",
     )
 
     # ONLY VISIBLE TO VALIDATOR
-    raw_logic_question: str = Field(
+    raw_logic_question: str = pydantic.Field(
         "",
         description="If this synapse from synthetic loop, this field will contain the raw logic question from the dataset.",
     )
-    ground_truth_answer: Union[str, object] = Field(
+    ground_truth_answer: Union[str, object] = pydantic.Field(
         "",
         description="Ground truth answer for the logic question. Very short, only the answer.",
     )
 
     # SYNAPSE INFORMATION
-    category: str = Field(
+    category: str = pydantic.Field(
         "",
         description="One of the categories in the Validator main.",
     )
-    timeout: int = Field(
+    timeout: int = pydantic.Field(
         64,
         description="Timeout for the miner to answer the logic question.",
-    )
-
-    terminal_info: Optional[TerminalInfo] = Field(
-        default=None,
-        description="Contains detailed information about the terminal involved in the communication process."
     )
 
     def miner_synapse(self):
@@ -63,3 +61,32 @@ class LogicSynapse(bt.Synapse):
             "logic_answer": self.logic_answer,
             "logic_reasoning": self.logic_reasoning,
         }
+
+
+class LogicRequest(pydantic.BaseModel):
+    """
+    Logic Synapse for the LogicNet protocol
+    """
+
+    # MINER NEED TO FILL THIS INFORMATION
+    logic_question: str = pydantic.Field(
+        "",
+        description="Logic question to be answered by miner. It can be noised question from the raw logic question from synthetic loop.",
+    )
+    logic_answer: Union[str, object] = pydantic.Field(
+        "", description="Short logic answer as a summary of the logic reasoning."
+    )
+    logic_reasoning: str = pydantic.Field(
+        "",
+        description="Reasoning when answering the logic question",
+    )
+
+    # SYNAPSE INFORMATION
+    category: str = pydantic.Field(
+        "",
+        description="One of the categories in the Validator main.",
+    )
+    timeout: int = pydantic.Field(
+        64,
+        description="Timeout for the miner to answer the logic question.",
+    )

--- a/logicnet/validator/miner_manager.py
+++ b/logicnet/validator/miner_manager.py
@@ -146,7 +146,9 @@ class MinerManager:
                 -NO_OF_RECENT_SCORES:
             ]
             self.all_uids_info[uid].reward_logs.append(reward_log)
-            self.all_uids_info[uid].reward_logs = self.all_uids_info[uid].reward_logs[-NO_OF_RECENT_SCORES:]
+            self.all_uids_info[uid].reward_logs = self.all_uids_info[uid].reward_logs[
+                -NO_OF_RECENT_SCORES:
+            ]
 
     def get_on_chain_weights(self, category) -> torch.Tensor:
         """

--- a/logicnet/validator/rewarder.py
+++ b/logicnet/validator/rewarder.py
@@ -188,8 +188,10 @@ class LogicRewarder:
             # Try programmatic comparison
             if self._compare_numerical_answers(ground_truth_answer, miner_answer):
                 correctness.append(1)
+                bt.logging.debug(f"Used programmatic comparison for response {idx} with answer {miner_answer} against ground truth {ground_truth_answer}")
             else:
                 # Need LLM evaluation
+                bt.logging.debug(f"Unable to use programmatic comparison. Need LLM evaluation for response {idx} with answer {miner_answer} against ground truth {ground_truth_answer}")
                 correctness.append(None)  # Placeholder
                 batch_messages.append([
                     {

--- a/neurons/miner/miner.py
+++ b/neurons/miner/miner.py
@@ -25,7 +25,7 @@ class Miner(BaseMinerNeuron):
         }
         self.num_processing_requests = 0
         self.total_request_in_interval = 0
-        bt.logging.info(f"Miner info: {self.miner_info}")
+        bt.logging.info(f"\033[1;32m🧠 Miner info: {self.miner_info}\033[0m")
         self.openai_client = openai.AsyncOpenAI(
             base_url=self.config.miner.llm_client.base_url,
             api_key=self.config.miner.llm_client.key,
@@ -44,16 +44,16 @@ class Miner(BaseMinerNeuron):
                 model=self.config.miner.llm_client.model,
             )
             self.num_processing_requests += 1
-            bt.logging.info(f"Start processing request {self.num_processing_requests}")
+            bt.logging.info(f"\033[1;33;44m🚀 Start processing request {self.num_processing_requests}\033[0m")
             self.total_request_in_interval += 1
             
         except Exception as e:
-            bt.logging.error(f"Error in forward: {e}")
+            bt.logging.error(f"\033[1;31m❌ Error in forward: {e}\033[0m")
             traceback.print_exc()
     
         finally:
             process_time = time.time() - start_time
-            bt.logging.info(f"\033[1;34mProcessing time for request {self.num_processing_requests}: {round(process_time,2)} seconds\033[0m")
+            bt.logging.info(f"\033[1;34;47m✅ Served request {self.num_processing_requests}: {round(process_time,2)} seconds\033[0m")
             
         return synapse
 
@@ -65,12 +65,12 @@ class Miner(BaseMinerNeuron):
         return False, "All passed!"
 
     async def blacklist(self, synapse: LogicSynapse) -> Tuple[bool, str]:
-        bt.logging.info(f"synapse in blacklist {synapse}")
+        bt.logging.info(f"\033[1;35m🛑 synapse in blacklist {synapse}\033[0m")
         try:
             if synapse.dendrite.hotkey not in self.metagraph.hotkeys:
                 # Ignore requests from unrecognized entities.
                 bt.logging.trace(
-                    f"Blacklisting unrecognized hotkey {synapse.dendrite.hotkey}"
+                    f"\033[1;35m🛑 Blacklisting unrecognized hotkey {synapse.dendrite.hotkey}\033[0m"
                 )
                 return True, "Unrecognized hotkey"
 
@@ -79,7 +79,7 @@ class Miner(BaseMinerNeuron):
 
             if validator_uid not in self.volume_per_validator:
                 bt.logging.trace(
-                    f"Blacklisting {validator_uid}-validator has {stake} stake"
+                    f"\033[1;35m🛑 Blacklisting {validator_uid}-validator has {stake} stake\033[0m"
                 )
                 return True, "Not enough stake"
             if logicnet.miner.check_limit(
@@ -90,13 +90,13 @@ class Miner(BaseMinerNeuron):
                 interval=self.config.miner.limit_interval,
             ):
                 bt.logging.trace(
-                    f"Blacklisting {validator_uid}-validator for exceeding the limit"
+                    f"\033[1;35m🛑 Blacklisting {validator_uid}-validator for exceeding the limit\033[0m"
                 )
                 return True, "Limit exceeded"
 
             return False, "All passed!"
         except Exception as e:
-            bt.logging.error(f"Error in blacklist: {e}")
+            bt.logging.error(f"\033[1;31m❌ Error in blacklist: {e}\033[0m")
             traceback.print_exc()
             return False, "All passed!"
 
@@ -108,7 +108,7 @@ class Miner(BaseMinerNeuron):
             self.metagraph.S[caller_uid]
         )  # Return the stake as the priority.
         bt.logging.trace(
-            f"Prioritizing {synapse.dendrite.hotkey} with value: ", priority
+            f"\033[1;36m🔝 Prioritizing {synapse.dendrite.hotkey} with value: {priority}\033[0m"
         )
         return priority
 
@@ -117,10 +117,10 @@ if __name__ == "__main__":
     with Miner() as miner:
         start_time = time.time()
         while True:
-            bt.logging.info("Miner running...", time.time())
+            bt.logging.info(f"\033[1;32m⛏️ Miner running... {time.time()}\033[0m")
             if time.time() - start_time > 300:
                 bt.logging.info(
-                    f"---Total request in last 5 minutes: {miner.total_request_in_interval}"
+                    f"\033[1;32m---Total request in last 5 minutes: {miner.total_request_in_interval}\033[0m"
                 )
                 start_time = time.time()
                 miner.total_request_in_interval = 0
@@ -133,5 +133,5 @@ if __name__ == "__main__":
                     )
                 )
             except Exception as e:
-                print(e)
+                bt.logging.error(f"\033[1;31m❌ Error updating volume per validator: {e}\033[0m")
             time.sleep(60)

--- a/neurons/miner/miner.py
+++ b/neurons/miner/miner.py
@@ -44,6 +44,7 @@ class Miner(BaseMinerNeuron):
                 model=self.config.miner.llm_client.model,
             )
             self.num_processing_requests += 1
+            bt.logging.info(f"Start processing request {self.num_processing_requests}")
             self.total_request_in_interval += 1
             
         except Exception as e:
@@ -52,7 +53,7 @@ class Miner(BaseMinerNeuron):
     
         finally:
             process_time = time.time() - start_time
-            bt.logging.info(f"Processing time: {process_time}")
+            bt.logging.info(f"\033[1;34mProcessing time for request {self.num_processing_requests}: {round(process_time,2)} seconds\033[0m")
             
         return synapse
 

--- a/neurons/miner/miner.py
+++ b/neurons/miner/miner.py
@@ -36,6 +36,7 @@ class Miner(BaseMinerNeuron):
         Forward pass for the miner neuron. This function is called when a synapse is received by the miner neuron.
         By default, Miner will utilize the LLM API to solve the logic problem.
         """
+        start_time = time.time()
         try:
             synapse = await solve(
                 synapse=synapse,
@@ -45,15 +46,14 @@ class Miner(BaseMinerNeuron):
             self.num_processing_requests += 1
             self.total_request_in_interval += 1
             
-            if synapse.terminal_info:
-                bt.logging.debug(f"TerminalInfo: {synapse.terminal_info}")
-            else:
-                bt.logging.debug("\033[1;31mTerminalInfo not available in synapse.\033[0m")
-            
         except Exception as e:
             bt.logging.error(f"Error in forward: {e}")
             traceback.print_exc()
-
+    
+        finally:
+            process_time = time.time() - start_time
+            bt.logging.info(f"Processing time: {process_time}")
+            
         return synapse
 
     async def forward_info(self, synapse: Information) -> Information:

--- a/neurons/miner/miner.py
+++ b/neurons/miner/miner.py
@@ -38,13 +38,13 @@ class Miner(BaseMinerNeuron):
         """
         start_time = time.time()
         try:
+            self.num_processing_requests += 1
+            bt.logging.info(f"\033[1;33;44m🚀 Start processing request {self.num_processing_requests}\033[0m")
             synapse = await solve(
                 synapse=synapse,
                 openai_client=self.openai_client,
                 model=self.config.miner.llm_client.model,
             )
-            self.num_processing_requests += 1
-            bt.logging.info(f"\033[1;33;44m🚀 Start processing request {self.num_processing_requests}\033[0m")
             self.total_request_in_interval += 1
             
         except Exception as e:
@@ -65,7 +65,7 @@ class Miner(BaseMinerNeuron):
         return False, "All passed!"
 
     async def blacklist(self, synapse: LogicSynapse) -> Tuple[bool, str]:
-        bt.logging.info(f"\033[1;35m🛑 synapse in blacklist {synapse}\033[0m")
+        bt.logging.info(f"synapse in blacklist {synapse}")
         try:
             if synapse.dendrite.hotkey not in self.metagraph.hotkeys:
                 # Ignore requests from unrecognized entities.

--- a/neurons/miner/miner.py
+++ b/neurons/miner/miner.py
@@ -44,6 +44,12 @@ class Miner(BaseMinerNeuron):
             )
             self.num_processing_requests += 1
             self.total_request_in_interval += 1
+            
+            if synapse.terminal_info:
+                bt.logging.debug(f"TerminalInfo: {synapse.terminal_info}")
+            else:
+                bt.logging.debug("\033[1;31mTerminalInfo not available in synapse.\033[0m")
+            
         except Exception as e:
             bt.logging.error(f"Error in forward: {e}")
             traceback.print_exc()

--- a/neurons/validator/validator.py
+++ b/neurons/validator/validator.py
@@ -39,7 +39,7 @@ class Validator(BaseValidatorNeuron):
         MAIN VALIDATOR that run the synthetic epoch and opening a proxy for receiving queries from the world.
         """
         super(Validator, self).__init__(config=config)
-        bt.logging.info("load_state()")
+        bt.logging.info("\033[1;32m🧠 load_state()\033[0m")
         self.categories = init_category(self.config)
         self.miner_manager = MinerManager(self)
         self.load_state()
@@ -53,11 +53,15 @@ class Validator(BaseValidatorNeuron):
         if self.config.proxy.port:
             try:
                 self.validator_proxy = ValidatorProxy(self)
-                bt.logging.info("Validator proxy started successfully")
+                bt.logging.info(
+                    "\033[1;32m🟢 Validator proxy started successfully\033[0m"
+                )
             except Exception:
                 bt.logging.warning(
-                    "Warning, proxy did not start correctly, so no one can query through your validator. Error message: "
+                    "\033[1;33m⚠️ Warning, proxy did not start correctly, so no one can query through your validator. "
+                    "This means you won't participate in queries from apps powered by this subnet. Error message: "
                     + traceback.format_exc()
+                    + "\033[0m"
                 )
 
     def forward(self):
@@ -66,7 +70,7 @@ class Validator(BaseValidatorNeuron):
         DEFAULT: 16 miners per batch, 600 seconds per loop.
         """
         self.store_miner_infomation()
-        bt.logging.info("Updating available models & uids")
+        bt.logging.info("\033[1;34m🔄 Updating available models & uids\033[0m")
         async_batch_size = self.config.async_batch_size
         loop_base_time = self.config.loop_base_time  # default is 600 seconds
         threads = []
@@ -80,7 +84,7 @@ class Validator(BaseValidatorNeuron):
             sleep_per_batch,
         ) in self.query_queue.get_batch_query(async_batch_size):
             bt.logging.info(
-                f"Querying {len(uids)} uids for model {category}, sleep_per_batch: {sleep_per_batch}"
+                f"\033[1;34m🔍 Querying {len(uids)} uids for model {category}, sleep_per_batch: {sleep_per_batch}\033[0m"
             )
 
             thread = threading.Thread(
@@ -90,7 +94,9 @@ class Validator(BaseValidatorNeuron):
             threads.append(thread)
             thread.start()
 
-            bt.logging.info(f"Sleeping for {sleep_per_batch} seconds between batches")
+            bt.logging.info(
+                f"\033[1;34m😴 Sleeping for {sleep_per_batch} seconds between batches\033[0m"
+            )
             time.sleep(sleep_per_batch)
 
         for thread in threads:
@@ -98,8 +104,9 @@ class Validator(BaseValidatorNeuron):
         self.update_scores_on_chain()
         self.save_state()
         bt.logging.info(
-            "Loop completed, uids info:\n",
-            str(self.miner_manager.all_uids_info).replace("},", "},\n"),
+            "\033[1;32m✅ Loop completed, uids info:\n"
+            + str(self.miner_manager.all_uids_info).replace("},", "},\n")
+            + "\033[0m"
         )
         self.store_miner_infomation()
 
@@ -107,7 +114,7 @@ class Validator(BaseValidatorNeuron):
 
         if actual_time_taken < loop_base_time:
             bt.logging.info(
-                f"Sleeping for {loop_base_time - actual_time_taken} seconds"
+                f"\033[1;34m😴 Sleeping for {loop_base_time - actual_time_taken} seconds\033[0m"
             )
             time.sleep(loop_base_time - actual_time_taken)
 
@@ -122,22 +129,31 @@ class Validator(BaseValidatorNeuron):
         synapses, batched_uids_should_rewards = self.prepare_challenge(
             uids_should_rewards, category
         )
+        
+        bt.logging.info(
+            "\033[1;35m==================== Getting the atom questions and answer ====================\033[0m"
+            )
+        
         for synapse, uids_should_rewards in zip(synapses, batched_uids_should_rewards):
             uids, should_rewards = zip(*uids_should_rewards)
-            bt.logging.info(f"Querying {uids}, Should reward: {should_rewards}")
+            bt.logging.info(
+                f"\033[1;34m🔍 Querying {uids}, Should reward: {should_rewards}\033[0m"
+            )
             if not synapse:
                 continue
             base_synapse = synapse.copy()
             synapse = synapse.miner_synapse()
             axons = [self.metagraph.axons[int(uid)] for uid in uids]
-            bt.logging.debug(f"Axon: {axons}")
+            bt.logging.debug(f"\033[1;34m🧠 Axon: {axons}\033[0m")
             responses = dendrite.query(
                 axons=axons,
                 synapse=synapse,
                 deserialize=False,
                 timeout=self.categories[category]["timeout"],
             )
-            bt.logging.debug(f"Miner response: {responses[0].logic_answer}")
+            bt.logging.debug(
+                f"\033[1;34m🧠 Miner response: {responses[0].logic_answer}\033[0m"
+            )
             reward_responses = [
                 response
                 for response, should_reward in zip(responses, should_rewards)
@@ -148,7 +164,11 @@ class Validator(BaseValidatorNeuron):
             ]
 
             bt.logging.info(
-                f"Received {len(responses)} responses, {len(reward_responses)} to be rewarded"
+                f"\033[1;34m🔍 Received {len(responses)} responses, {len(reward_responses)} to be rewarded\033[0m"
+            )
+
+            bt.logging.info(
+                "\033[1;36m==================== Querying revised request to miners ====================\033[0m"
             )
 
             if reward_uids:
@@ -163,7 +183,7 @@ class Validator(BaseValidatorNeuron):
                             + 0.1 * self.miner_manager.all_uids_info[uid].reward_scale
                         )
 
-                bt.logging.info(f"Scored responses: {rewards}")
+                bt.logging.info(f"\033[1;32m🏆 Scored responses: {rewards}\033[0m")
 
                 self.miner_manager.update_scores(uids, rewards, reward_logs)
 
@@ -209,17 +229,19 @@ class Validator(BaseValidatorNeuron):
                 model_specific_weights * self.categories[category]["incentive_weight"]
             )
             bt.logging.info(
-                f"model_specific_weights for {category}\n{model_specific_weights}"
+                f"\033[1;34m⚖️ model_specific_weights for {category}\n{model_specific_weights}\033[0m"
             )
             weights = weights + model_specific_weights
 
         # Check if rewards contains NaN values.
         if torch.isnan(weights).any():
-            bt.logging.warning(f"NaN values detected in weights: {weights}")
+            bt.logging.warning(
+                f"\033[1;33m⚠️ NaN values detected in weights: {weights}\033[0m"
+            )
             # Replace any NaN values in rewards with 0.
             weights = torch.nan_to_num(weights, 0)
         self.scores: torch.FloatTensor = weights
-        bt.logging.success(f"Updated scores: {self.scores}")
+        bt.logging.success(f"\033[1;32m✅ Updated scores: {self.scores}\033[0m")
 
     def save_state(self):
         """Saves the state of the validator to a file."""
@@ -238,17 +260,21 @@ class Validator(BaseValidatorNeuron):
         # Load the state of the validator from file.
         try:
             path = self.config.neuron.full_path + "/state.pt"
-            bt.logging.info("Loading validator state from: " + path)
+            bt.logging.info(
+                "\033[1;32m🧠 Loading validator state from: " + path + "\033[0m"
+            )
             state = torch.load(path)
             self.step = state["step"]
             all_uids_info = state["all_uids_info"]
             for k, v in all_uids_info.items():
                 v = v.to_dict()
                 self.miner_manager.all_uids_info[k] = MinerInfo(**v)
-            bt.logging.info("Successfully loaded state")
+            bt.logging.info("\033[1;32m✅ Successfully loaded state\033[0m")
         except Exception as e:
             self.step = 0
-            bt.logging.info("Could not find previously saved state.", e)
+            bt.logging.info(
+                "\033[1;33m⚠️ Could not find previously saved state.\033[0m", e
+            )
 
     def store_miner_infomation(self):
         miner_informations = self.miner_manager.to_dict()
@@ -273,5 +299,5 @@ class Validator(BaseValidatorNeuron):
 if __name__ == "__main__":
     with Validator() as validator:
         while True:
-            bt.logging.info("Validator running...", time.time())
+            bt.logging.info("\033[1;32m🟢 Validator running...\033[0m", time.time())
             time.sleep(360)

--- a/neurons/validator/validator.py
+++ b/neurons/validator/validator.py
@@ -130,10 +130,6 @@ class Validator(BaseValidatorNeuron):
             uids_should_rewards, category
         )
         
-        bt.logging.info(
-            "\033[1;35m==================== Getting the atom questions and answer ====================\033[0m"
-            )
-        
         for synapse, uids_should_rewards in zip(synapses, batched_uids_should_rewards):
             uids, should_rewards = zip(*uids_should_rewards)
             bt.logging.info(
@@ -165,10 +161,6 @@ class Validator(BaseValidatorNeuron):
 
             bt.logging.info(
                 f"\033[1;34m🔍 Received {len(responses)} responses, {len(reward_responses)} to be rewarded\033[0m"
-            )
-
-            bt.logging.info(
-                "\033[1;36m==================== Querying revised request to miners ====================\033[0m"
             )
 
             if reward_uids:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ numpy==1.26.4
 openai==1.35.14
 sentence-transformers==3.0.1
 python-dotenv==1.0.1
+sympy
 git+https://github.com/lukew3/mathgenerator.git


### PR DESCRIPTION
**Pull Request Description:**
- Adding programmatic accuracy validation function and only use LLM as fall back to enhance the accuracy and reliability of the correctness scoring, and also to save time and tokens.
- Addressing the issue where validators were being incorrectly blacklisted due to the `max_request` value not updating when a validator's stake changed within the interval period.
- Improve Logging for Miner and Validator to improve readability. 

**Problem:**
- The validator constantly running the model to evaluate the accuracy of the miners which slow down the pipeline and cause more token money for those who running api instead of locally.
- The `check_limit` function only updated the `max_request` for a validator when the validator was first encountered or when the interval reset.
- If a validator's stake increased (resulting in a higher `max_request`) before the interval reset, the `max_request` in `self.validator_logs` remained outdated.
- This caused validators to be blacklisted even though they had not exceeded their new, higher `max_request` limits.
- Log are all in mono colors which make it looks like a cluster and hard to read and track down issues during debugs

**Solution:**
- Handle Numerical Equivalence Programmatically: For numerical answers, the validator will compare the miner's answer to the ground truth programmatically using `sympy`. Bypasses the need for the LLM in straightforward numerical comparisons (still use as backup in case the answer is unable to evaluate programmatically). Reduces reliance on the LLM's judgment.
- Modify the `check_limit` function to update the `max_request` for each validator every time the function is called, regardless of the interval.
- Ensure that the `request_counter` is compared against the updated `max_request` to accurately reflect the validator's current stake and allowed request volume.
- Adding flare and colors to the logs also include highlight colors to create seperation between prompt
- Adding time process tracking to track how long it takes for miner to serve a prompt 

**Testing:**
- Tested with validators whose stakes change within the interval to ensure `max_request` updates appropriately.
- Monitored logs to confirm that `request_counter` resets and `max_request` reflects current stakes.
