### PR TITLE
update the current miner reward distribution

### DIFF
--- a/logicnet/validator/rewarder.py
+++ b/logicnet/validator/rewarder.py
@@ -126,43 +126,9 @@ class LogicRewarder:
                     f"[REWARDER] similarity: {similarities[i]}, correctness: {correctness[i]}, processing time: {process_times[i]}"
                 )
                 valid_rewards.append(reward)
-            
-            """
-            Calculate incentive rewards based on the rank.
-            Get the incentive rewards for the valid responses using the cubic function and valid_rewards rank.
-            """
-            # Enumerate rewards with their original index
-            original_rewards = list(enumerate(valid_rewards))
-
-            # Sort rewards in descending order based on the score
-            sorted_rewards = sorted(original_rewards, key=lambda x: x[1], reverse=True)
-
-            # Calculate ranks, handling ties
-            ranks = []
-            previous_score = None
-            # Initialize rank to 0
-            rank = 0
-            for i, (reward_id, score) in enumerate(sorted_rewards):
-                rank = i + 1 if score != previous_score else rank  # Update rank only if the score changes
-                ranks.append((reward_id, rank, score))
-                previous_score = score
-
-            # Restore the original order of rewards
-            ranks.sort(key=lambda x: x[0])
-
-            # Calculate incentive rewards based on the rank, applying the cubic function for positive scores
-            def incentive_formula(rank):
-                reward_value = -1.038e-7 * rank**3 + 6.214e-5 * rank**2 - 0.0129 * rank - 0.0118
-                # Scale up the reward value between 0 and 1
-                scaled_reward_value = reward_value + 1
-                return scaled_reward_value
-            
-            incentive_rewards = [
-                (incentive_formula(rank) if score > 0 else 0) for _, rank, score in ranks
-            ]
-
+                
         total_uids = valid_uids + invalid_uids
-        rewards = incentive_rewards + invalid_rewards
+        rewards = valid_rewards + invalid_rewards
         return total_uids, rewards, reward_logs
 
     def _get_correctness(

--- a/neurons/miner/miner.py
+++ b/neurons/miner/miner.py
@@ -65,39 +65,39 @@ class Miner(BaseMinerNeuron):
         return False, "All passed!"
 
     async def blacklist(self, synapse: LogicSynapse) -> Tuple[bool, str]:
-        bt.logging.info(f"synapse in blacklist {synapse}")
-        try:
-            if synapse.dendrite.hotkey not in self.metagraph.hotkeys:
-                # Ignore requests from unrecognized entities.
-                bt.logging.trace(
-                    f"\033[1;35m🛑 Blacklisting unrecognized hotkey {synapse.dendrite.hotkey}\033[0m"
-                )
-                return True, "Unrecognized hotkey"
+        # bt.logging.info(f"synapse in blacklist {synapse}")
+        # try:
+        #     if synapse.dendrite.hotkey not in self.metagraph.hotkeys:
+        #         # Ignore requests from unrecognized entities.
+        #         bt.logging.trace(
+        #             f"\033[1;35m🛑 Blacklisting unrecognized hotkey {synapse.dendrite.hotkey}\033[0m"
+        #         )
+        #         return True, "Unrecognized hotkey"
 
-            validator_uid = self.metagraph.hotkeys.index(synapse.dendrite.hotkey)
-            stake = self.metagraph.stake[validator_uid].item()
+        #     validator_uid = self.metagraph.hotkeys.index(synapse.dendrite.hotkey)
+        #     stake = self.metagraph.stake[validator_uid].item()
 
-            if validator_uid not in self.volume_per_validator:
-                bt.logging.trace(
-                    f"\033[1;35m🛑 Blacklisting {validator_uid}-validator has {stake} stake\033[0m"
-                )
-                return True, "Not enough stake"
-            if logicnet.miner.check_limit(
-                self,
-                uid=validator_uid,
-                stake=stake,
-                volume_per_validator=self.volume_per_validator,
-                interval=self.config.miner.limit_interval,
-            ):
-                bt.logging.trace(
-                    f"\033[1;35m🛑 Blacklisting {validator_uid}-validator for exceeding the limit\033[0m"
-                )
-                return True, "Limit exceeded"
+        #     if validator_uid not in self.volume_per_validator:
+        #         bt.logging.trace(
+        #             f"\033[1;35m🛑 Blacklisting {validator_uid}-validator has {stake} stake\033[0m"
+        #         )
+        #         return True, "Not enough stake"
+        #     if logicnet.miner.check_limit(
+        #         self,
+        #         uid=validator_uid,
+        #         stake=stake,
+        #         volume_per_validator=self.volume_per_validator,
+        #         interval=self.config.miner.limit_interval,
+        #     ):
+        #         bt.logging.trace(
+        #             f"\033[1;35m🛑 Blacklisting {validator_uid}-validator for exceeding the limit\033[0m"
+        #         )
+        #         return True, "Limit exceeded"
 
-            return False, "All passed!"
-        except Exception as e:
-            bt.logging.error(f"\033[1;31m❌ Error in blacklist: {e}\033[0m")
-            traceback.print_exc()
+        #     return False, "All passed!"
+        # except Exception as e:
+        #     bt.logging.error(f"\033[1;31m❌ Error in blacklist: {e}\033[0m")
+        #     traceback.print_exc()
             return False, "All passed!"
 
     async def priority(self, synapse: LogicSynapse) -> float:

--- a/neurons/miner/miner.py
+++ b/neurons/miner/miner.py
@@ -65,39 +65,39 @@ class Miner(BaseMinerNeuron):
         return False, "All passed!"
 
     async def blacklist(self, synapse: LogicSynapse) -> Tuple[bool, str]:
-        # bt.logging.info(f"synapse in blacklist {synapse}")
-        # try:
-        #     if synapse.dendrite.hotkey not in self.metagraph.hotkeys:
-        #         # Ignore requests from unrecognized entities.
-        #         bt.logging.trace(
-        #             f"\033[1;35m🛑 Blacklisting unrecognized hotkey {synapse.dendrite.hotkey}\033[0m"
-        #         )
-        #         return True, "Unrecognized hotkey"
+        bt.logging.info(f"synapse in blacklist {synapse}")
+        try:
+            if synapse.dendrite.hotkey not in self.metagraph.hotkeys:
+                # Ignore requests from unrecognized entities.
+                bt.logging.trace(
+                    f"\033[1;35m🛑 Blacklisting unrecognized hotkey {synapse.dendrite.hotkey}\033[0m"
+                )
+                return True, "Unrecognized hotkey"
 
-        #     validator_uid = self.metagraph.hotkeys.index(synapse.dendrite.hotkey)
-        #     stake = self.metagraph.stake[validator_uid].item()
+            validator_uid = self.metagraph.hotkeys.index(synapse.dendrite.hotkey)
+            stake = self.metagraph.stake[validator_uid].item()
 
-        #     if validator_uid not in self.volume_per_validator:
-        #         bt.logging.trace(
-        #             f"\033[1;35m🛑 Blacklisting {validator_uid}-validator has {stake} stake\033[0m"
-        #         )
-        #         return True, "Not enough stake"
-        #     if logicnet.miner.check_limit(
-        #         self,
-        #         uid=validator_uid,
-        #         stake=stake,
-        #         volume_per_validator=self.volume_per_validator,
-        #         interval=self.config.miner.limit_interval,
-        #     ):
-        #         bt.logging.trace(
-        #             f"\033[1;35m🛑 Blacklisting {validator_uid}-validator for exceeding the limit\033[0m"
-        #         )
-        #         return True, "Limit exceeded"
+            if validator_uid not in self.volume_per_validator:
+                bt.logging.trace(
+                    f"\033[1;35m🛑 Blacklisting {validator_uid}-validator has {stake} stake\033[0m"
+                )
+                return True, "Not enough stake"
+            if logicnet.miner.check_limit(
+                self,
+                uid=validator_uid,
+                stake=stake,
+                volume_per_validator=self.volume_per_validator,
+                interval=self.config.miner.limit_interval,
+            ):
+                bt.logging.trace(
+                    f"\033[1;35m🛑 Blacklisting {validator_uid}-validator for exceeding the limit\033[0m"
+                )
+                return True, "Limit exceeded"
 
-        #     return False, "All passed!"
-        # except Exception as e:
-        #     bt.logging.error(f"\033[1;31m❌ Error in blacklist: {e}\033[0m")
-        #     traceback.print_exc()
+            return False, "All passed!"
+        except Exception as e:
+            bt.logging.error(f"\033[1;31m❌ Error in blacklist: {e}\033[0m")
+            traceback.print_exc()
             return False, "All passed!"
 
     async def priority(self, synapse: LogicSynapse) -> float:

--- a/neurons/validator/validator.py
+++ b/neurons/validator/validator.py
@@ -50,6 +50,9 @@ class Validator(BaseValidatorNeuron):
             list(self.categories.keys()),
             time_per_loop=self.config.loop_base_time,
         )
+        self.miner_scores = []
+        self.miner_reward_logs = []
+        self.miner_uids = []
         if self.config.proxy.port:
             try:
                 self.validator_proxy = ValidatorProxy(self)
@@ -98,6 +101,13 @@ class Validator(BaseValidatorNeuron):
                 f"\033[1;34m😴 Sleeping for {sleep_per_batch} seconds between batches\033[0m"
             )
             time.sleep(sleep_per_batch)
+
+        bt.logging.debug(f"[1111111111111111111111VALIDATOR] Miner scores: {self.miner_scores}")
+        bt.logging.debug(f"[1111111111111111111111VALIDATOR] Miner reward logs: {self.miner_reward_logs}")
+        bt.logging.debug(f"[1111111111111111111111VALIDATOR] Miner uids: {self.miner_uids}")
+        if self.miner_scores and self.miner_reward_logs and self.miner_uids:
+            self.assign_incentive_rewards(self.miner_uids, self.miner_scores, self.miner_reward_logs)
+        
 
         for thread in threads:
             thread.join()
@@ -176,8 +186,57 @@ class Validator(BaseValidatorNeuron):
                         )
 
                 bt.logging.info(f"\033[1;32m🏆 Scored responses: {rewards}\033[0m")
+                self.miner_reward_logs.append(reward_logs[0])
+                self.miner_uids.append(uids[0]) 
+                self.miner_scores.append(rewards[0])
 
-                self.miner_manager.update_scores(uids, rewards, reward_logs)
+    def assign_incentive_rewards(self, uids, rewards, reward_logs):
+        """
+        Calculate incentive rewards based on the rank.
+        Get the incentive rewards for the valid responses using the cubic function and valid_rewards rank.
+        """
+        bt.logging.debug(f"[11111111] Valid rewards: {rewards}")
+        bt.logging.debug(f"[11111111] Valid uids: {uids}")
+        bt.logging.debug(f"[11111111] Valid reward logs: {reward_logs}")
+        # Enumerate rewards with their original index
+        original_rewards = list(enumerate(rewards))
+        bt.logging.debug(f"[REWARDER] Original rewards: {original_rewards}")
+        # Sort rewards in descending order based on the score
+        sorted_rewards = sorted(original_rewards, key=lambda x: x[1], reverse=True)
+        # Calculate ranks, handling ties
+        ranks = []
+        previous_score = None
+        rank = 0
+        for i, (reward_id, score) in enumerate(sorted_rewards):
+            rank = i + 1 if score != previous_score else rank  # Update rank only if the score changes
+            ranks.append((reward_id, rank, score))
+            previous_score = score
+        # Restore the original order of rewards
+        ranks.sort(key=lambda x: x[0])
+
+        # Calculate incentive rewards based on the rank, applying the cubic function for positive scores
+        def incentive_formula(rank):
+            reward_value = -1.038e-7 * rank**3 + 6.214e-5 * rank**2 - 0.0129 * rank - 0.0118
+            # Scale up the reward value between 0 and 1
+            scaled_reward_value = reward_value + 1
+            return scaled_reward_value
+        
+        incentive_rewards = [
+            (incentive_formula(rank) if score > 0 else 0) for _, rank, score in ranks
+        ]
+
+        # # Normalize the incentive rewards so that their sum is 1
+        # total_reward = sum(incentive_rewards)
+        # if total_reward > 0:
+        #     incentive_rewards = [reward / total_reward for reward in incentive_rewards]
+
+        bt.logging.debug(f"[22222222] Incentive rewards: {incentive_rewards}")
+        bt.logging.debug(f"[22222222] Uids: {uids}")
+        bt.logging.debug(f"[22222222] Reward logs: {reward_logs}")  
+        self.miner_manager.update_scores(uids, incentive_rewards, reward_logs)
+        self.miner_scores = []
+        self.miner_reward_logs = []
+        self.miner_uids = []
 
     def prepare_challenge(self, uids_should_rewards, category):
         """

--- a/neurons/validator/validator.py
+++ b/neurons/validator/validator.py
@@ -102,9 +102,6 @@ class Validator(BaseValidatorNeuron):
             )
             time.sleep(sleep_per_batch)
 
-        bt.logging.debug(f"[1111111111111111111111VALIDATOR] Miner scores: {self.miner_scores}")
-        bt.logging.debug(f"[1111111111111111111111VALIDATOR] Miner reward logs: {self.miner_reward_logs}")
-        bt.logging.debug(f"[1111111111111111111111VALIDATOR] Miner uids: {self.miner_uids}")
         if self.miner_scores and self.miner_reward_logs and self.miner_uids:
             self.assign_incentive_rewards(self.miner_uids, self.miner_scores, self.miner_reward_logs)
         

--- a/neurons/validator/validator.py
+++ b/neurons/validator/validator.py
@@ -195,12 +195,9 @@ class Validator(BaseValidatorNeuron):
         Calculate incentive rewards based on the rank.
         Get the incentive rewards for the valid responses using the cubic function and valid_rewards rank.
         """
-        bt.logging.debug(f"[11111111] Valid rewards: {rewards}")
-        bt.logging.debug(f"[11111111] Valid uids: {uids}")
-        bt.logging.debug(f"[11111111] Valid reward logs: {reward_logs}")
         # Enumerate rewards with their original index
         original_rewards = list(enumerate(rewards))
-        bt.logging.debug(f"[REWARDER] Original rewards: {original_rewards}")
+        
         # Sort rewards in descending order based on the score
         sorted_rewards = sorted(original_rewards, key=lambda x: x[1], reverse=True)
         # Calculate ranks, handling ties
@@ -230,9 +227,6 @@ class Validator(BaseValidatorNeuron):
         # if total_reward > 0:
         #     incentive_rewards = [reward / total_reward for reward in incentive_rewards]
 
-        bt.logging.debug(f"[22222222] Incentive rewards: {incentive_rewards}")
-        bt.logging.debug(f"[22222222] Uids: {uids}")
-        bt.logging.debug(f"[22222222] Reward logs: {reward_logs}")  
         self.miner_manager.update_scores(uids, incentive_rewards, reward_logs)
         self.miner_scores = []
         self.miner_reward_logs = []


### PR DESCRIPTION
[Reason for flat distribution]
The reason for the flat distribution is that we select one miner, query a validator request to that miner, and evaluate the score only once. This process is asynchronous. I initially misunderstood that the `valid_rewards `in rewarder.py contained an array (similar to what the synchronous code does), but it actually holds a single reward element for a single selected miner. In this context, the mechanism proceeds with miner ranking and a cubic function, resulting in all miner responses converging to a single value.

[Solution]
After logging and tracking, I discovered this issue and modified the code to align with the asynchronous behavior. I collected all miner rewards and passed them to a new function, `assign_incentive_rewards`, which follows the same logic and workflow as the one I implemented in rewarder.py already.