### PR TITLE
Improve scoring logic to consider miners best score per epoch

### DIFF
--- a/logicnet/validator/rewarder.py
+++ b/logicnet/validator/rewarder.py
@@ -142,10 +142,10 @@ class LogicRewarder:
             score = self._compare_numerical_answers(ground_truth_answer, miner_answer)
             if score is not None:
                 correctness.append(score)
-                bt.logging.debug(f"[CORRECTNESS] Used programmatic comparison for response {idx} with score {score} for answer {miner_answer} against ground truth {ground_truth_answer}")
+                bt.logging.debug(f"[CORRECTNESS] Used programmatic comparison for response {idx} with score {score}")
             else:
                 # Need LLM evaluation
-                bt.logging.debug(f"[CORRECTNESS] Unable to use programmatic comparison. Need LLM evaluation for response {idx} with answer {miner_answer} against ground truth {ground_truth_answer}")
+                bt.logging.debug(f"[CORRECTNESS] Unable to use programmatic comparison. Need LLM evaluation for response {idx}")
                 correctness.append(None)  # Placeholder
                 batch_messages.append([
                     {

--- a/neurons/validator/validator.py
+++ b/neurons/validator/validator.py
@@ -241,51 +241,56 @@ class Validator(BaseValidatorNeuron):
                     self.miner_scores.append(rewards)
 
     def assign_incentive_rewards(self, uids, rewards, reward_logs):
-        """
-        Calculate incentive rewards based on the rank.
-        Get the incentive rewards for the valid responses using the cubic function and valid_rewards rank.
-        """
         # Flatten the nested lists
         flat_uids = [uid for uid_list in uids for uid in uid_list]
         flat_rewards = [reward for reward_list in rewards for reward in reward_list]
         flat_reward_logs = [log for log_list in reward_logs for log in log_list]
-
-        # Enumerate rewards with their original index
-        original_rewards = list(enumerate(flat_rewards))
         
-        # Sort rewards in descending order based on the score
+        # Create a dictionary to track the best score per UID
+        best_scores = {}
+        best_logs = {}
+        for uid, reward, log in zip(flat_uids, flat_rewards, flat_reward_logs):
+            if uid not in best_scores or reward > best_scores[uid]:
+                best_scores[uid] = reward
+                best_logs[uid] = log
+
+        # Now best_scores holds the highest reward each UID achieved this epoch
+        # Convert them into lists for processing
+        final_uids = list(best_scores.keys())
+        final_rewards = list(best_scores.values())
+        final_logs = list(best_logs.values())
+        
+        # Now proceed with the incentive rewards calculation on these best attempts
+        original_rewards = list(enumerate(final_rewards))
+        # Sort and rank as before, but now we're only dealing with the best attempt per UID
         sorted_rewards = sorted(original_rewards, key=lambda x: x[1], reverse=True)
         
-        # Calculate ranks, handling ties
         ranks = []
         previous_score = None
         rank = 0
         for i, (reward_id, score) in enumerate(sorted_rewards):
-            rank = i + 1 if score != previous_score else rank  # Update rank only if the score changes
+            rank = i + 1 if score != previous_score else rank
             ranks.append((reward_id, rank, score))
             previous_score = score
         
-        # Restore the original order of rewards
+        # Restore original order
         ranks.sort(key=lambda x: x[0])
-
-        # Calculate incentive rewards based on the rank, applying the cubic function for positive scores
+        
         def incentive_formula(rank):
             reward_value = -1.038e-7 * rank**3 + 6.214e-5 * rank**2 - 0.0129 * rank - 0.0118
-            # Scale up the reward value between 0 and 1
             scaled_reward_value = reward_value + 1
             return scaled_reward_value
         
-        incentive_rewards = [
-            (incentive_formula(rank) if score > 0 else 0) for _, rank, score in ranks
-        ]
+        incentive_rewards = [(incentive_formula(rank) if score > 0 else 0) for _, rank, score in ranks]
         
-        # Update scores on chain
-        self.miner_manager.update_scores(flat_uids, incentive_rewards, flat_reward_logs)
+        # Update scores on chain with only the best attempts
+        self.miner_manager.update_scores(final_uids, incentive_rewards, final_logs)
         
-        # Reset the miner reward logs, uids, and scores for next loop
+        # Reset logs for next epoch
         self.miner_scores = []
         self.miner_reward_logs = []
         self.miner_uids = []
+
 
     def prepare_challenge(self, uids_should_rewards, category):
         """


### PR DESCRIPTION
This PR modifies the reward logic to consider the miner’s mean score per epoch rather than just their first attempt. Previously, only the first response from each UID during the epoch was rewarded, causing all subsequent attempts to be ignored. With this change:
- All attempts from each UID are scored throughout the epoch.
- At epoch’s end, mean score are calculated for each UID is selected and used for final incentive calculations.
- Mean scores are turned into final incentive rewards and recorded on-chain.
- This ensures that miners can improve their standing over time and are not penalized by one poor early attempt.

**Results:**
- Miners can improve their standing over the course of the epoch.
- Random initial difficulties won't lock a miner into a bad score for the entire epoch.
- Scoring now reflects the best performance of each miner within the epoch, as intended.